### PR TITLE
Break Dash Stun

### DIFF
--- a/scripts/playerGetShocked.gml
+++ b/scripts/playerGetShocked.gml
@@ -24,6 +24,11 @@ if (!isHit && (_IgnoreGround || ground))
         }
         else
         {
+            if (instance_exists(objBreakDash))
+            { 
+                xspeed = 0; //stops you dead in your tracks.
+            }
+            
             shootTimer = 0;
             isShocked = true;
             isShoot = 0;


### PR DESCRIPTION
There was a reported case of being Stunned kept your Break Dash momentum, this fix basically stops the player dead in their tracks on top of applying stun.