### PR TITLE
 Fix: objWeaponSettings reset wrong variable in "room end"

### DIFF
--- a/objects/objWeaponSettings.object.gmx
+++ b/objects/objWeaponSettings.object.gmx
@@ -101,7 +101,7 @@ global.lockBuster = false;
 
 for (i = 0; i &lt;= global.totalWeapons; i += 1)
 {
-    global.weaponUnlocked[i] = true;
+    global.weaponLocked[i] = false;
     global.infiniteEnergy[i] = false;
 }
 </string>


### PR DESCRIPTION
With the previous code, weapons remained locked between levels. With the new code, they reset as they're supposed to (as a side effect, I think the previous code could permanently unlock weapons, which I don't think it was supposed to).

Hope I didn't break anything with the pull request. I got the weirdest of merge conflicts and had to resolve them manually. However, this fix is literally just a single line, so if this pull request happens to be bogus, feel free to just manually copy this one changed line over.