### PR TITLE
Sound loop volume fix.

### DIFF
--- a/scripts/loopSFX.gml
+++ b/scripts/loopSFX.gml
@@ -2,4 +2,5 @@
 // Loops a sound effect
 
 audio_stop_sound(argument0);
-audio_play_sound(argument0, 60, 1);
+var mySound = audio_play_sound(argument0, 60, 1);
+audio_sound_gain(mySound, global.soundvolume * 0.01, 0);


### PR DESCRIPTION
LoopSFX currently doesn't specify the volume for a looping sound, defaulting it to 1 and having it play even if the sounds should be muted. Provided is a proposed fix.