### PR TITLE
Constansts number fix

### DIFF
--- a/MegamixEngine.project.gmx
+++ b/MegamixEngine.project.gmx
@@ -6886,7 +6886,7 @@
       <room>rooms\lvlTestHallBoss</room>
     </rooms>
   </rooms>
-  <constants number="36">
+  <constants number="39">
     <constant name="PL_LOCK_MAX">14</constant>
     <constant name="PL_LOCK_AERIAL">13</constant>
     <constant name="PL_LOCK_GROUND">12</constant>


### PR DESCRIPTION
As the number of constants were actually 39 and not 36, GMS completely ignored the GME_ENABLED, FMOD_ENABLED, FS_ENABLED constansts.